### PR TITLE
Add scrollview delegate callbacks for endingDragging

### DIFF
--- a/MXSegmentedPager/MXSegmentedPager.h
+++ b/MXSegmentedPager/MXSegmentedPager.h
@@ -86,12 +86,20 @@ typedef void (^MXProgressBlock) (CGFloat progress);
 - (CGFloat) heightForSegmentedControlInSegmentedPager:(MXSegmentedPager*)segmentedPager;
 
 /**
- Tells the delegate that the segmented pagr has scrolled with the parallax header.
+ Tells the delegate that the segmented pager has scrolled with the parallax header.
  
  @param segmentedPager A segmented-pager object informing the delegate about the impending selection.
  @param parallaxHeader The parallax-header that has scrolled.
  */
 - (void) segmentedPager:(MXSegmentedPager*)segmentedPager didScrollWithParallaxHeader:(MXParallaxHeader *)parallaxHeader;
+
+/**
+ Tells the delegate the segmented pager has completed dragging with the parallax header.
+ 
+ @param segmentedPager A segmented-pager object informing the delegate about the impending selection.
+ @param parallaxHeader The parallax-header that has scrolled.
+ */
+- (void) segmentedPager:(MXSegmentedPager *)segmentedPager didEndDraggingWithParallaxHeader:(MXParallaxHeader *)parallaxHeader;
 
 @end
 

--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -213,6 +213,12 @@
     }
 }
 
+- (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate {
+    if ([self.delegate respondsToSelector:@selector(segmentedPager:didEndDraggingWithParallaxHeader:)]) {
+        [self.delegate segmentedPager:self didEndDraggingWithParallaxHeader:scrollView.parallaxHeader];
+    }
+}
+
 - (BOOL)scrollView:(MXScrollView *)scrollView shouldScrollWithSubView:(UIView *)subView {
     UIView<MXPageProtocol> *page = (id) self.pager.selectedPage;
     


### PR DESCRIPTION
- [x] Adds delegate callback for when the scrollview dragging has ended. 

As a consumer of the segmented pager, when there is a header on screen, I'd like to get extra a callback when the scrollview is done dragging and what the current header progress value might be.
