### PR TITLE
Add scroll to top functionality

### DIFF
--- a/MXSegmentedPager/MXSegmentedPager.h
+++ b/MXSegmentedPager/MXSegmentedPager.h
@@ -210,7 +210,7 @@ typedef void (^MXProgressBlock) (CGFloat progress);
 /**
  Scrolls the main contentView back to the top position
  */
-- (void) scrollToTop;
+- (void) scrollToTopAnimated:(BOOL)animated;
 
 @end
 

--- a/MXSegmentedPager/MXSegmentedPager.h
+++ b/MXSegmentedPager/MXSegmentedPager.h
@@ -207,6 +207,11 @@ typedef void (^MXProgressBlock) (CGFloat progress);
  */
 - (void) reloadData;
 
+/**
+ Scrolls the main contentView back to the top position
+ */
+- (void) scrollToTop;
+
 @end
 
 /**

--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -86,6 +86,10 @@
     [self.pager reloadData];
 }
 
+- (void)scrollToTop {
+    [_contentView setContentOffset:CGPointMake(0, -self.contentView.parallaxHeader.height) animated:YES];
+}
+
 #pragma mark Layout
 
 - (void)layoutSubviews {

--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -86,9 +86,10 @@
     [self.pager reloadData];
 }
 
-- (void)scrollToTop {
-    [_contentView setContentOffset:CGPointMake(0, -self.contentView.parallaxHeader.height) animated:YES];
+- (void)scrollToTopAnimated:(BOOL)animated {
+    [_contentView setContentOffset:CGPointMake(0, -self.contentView.parallaxHeader.height) animated:animated];
 }
+
 
 #pragma mark Layout
 


### PR DESCRIPTION
- [x] Adds a method to scroll the main contentView to the top.

Since the contentView is private and I think it's okay to remain private, I needed a way to implement scroll to top such that it also accounts for whatever the header's height is.
