### PR TITLE
Forwards shouldScrollToTop delegate callbacks to segmentedPager

### DIFF
--- a/MXSegmentedPager/MXSegmentedPager.h
+++ b/MXSegmentedPager/MXSegmentedPager.h
@@ -101,6 +101,14 @@ typedef void (^MXProgressBlock) (CGFloat progress);
  */
 - (void) segmentedPager:(MXSegmentedPager *)segmentedPager didEndDraggingWithParallaxHeader:(MXParallaxHeader *)parallaxHeader;
 
+/**
+ Forwards the delegate method `shouldScrollToTop` to the delegate. Defaults to `YES` when not implemented
+
+ @param segmentedPager A segmented-pager object informing the delegate about the impending selection.
+ @param scrollView A scrollview forwarding the corresponding delegate method
+ */
+- (BOOL) segmentedPager:(MXSegmentedPager *)segmentedPager shouldScrollToTop:(UIScrollView *)scrollView;
+
 @end
 
 /**

--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -233,6 +233,14 @@
     return YES;
 }
 
+- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView {
+    if ([self.delegate respondsToSelector:@selector(segmentedPager:shouldScrollToTop:)]) {
+        return [self.delegate segmentedPager:self shouldScrollToTop:scrollView];
+    } else {
+        return YES;
+    }
+}
+
 #pragma mark HMSegmentedControl target
 
 - (void)pageControlValueChanged:(HMSegmentedControl*)segmentedControl {


### PR DESCRIPTION
Adds a new delegate for forwarding the `shouldScrollToTop` scroll view delegate callback.

This allows other consumers to listen in for scrolling related calls that are received on the main `MXScrollView` and do other actions if necessary. 
