### PR TITLE
fix depreсation of sticky header

### DIFF
--- a/MXSegmentedPager/MXSegmentedPager.h
+++ b/MXSegmentedPager/MXSegmentedPager.h
@@ -278,7 +278,7 @@ typedef NS_ENUM(NSInteger, MXParallaxHeaderStickyViewPosition) {
     MXParallaxHeaderStickyViewPositionTop,
 };
 
-@interface MXParallaxHeader (StyckyHeader)
+@interface MXParallaxHeader (StickyHeader)
 @property (nonatomic, assign, readwrite) MXParallaxHeaderStickyViewPosition stickyViewPosition;
 @property (nonatomic, strong, nullable, readwrite) NSLayoutConstraint *stickyViewHeightConstraint;
 @property (nonatomic, strong, nullable, readwrite) UIView *stickyView;

--- a/MXSegmentedPager/MXSegmentedPager.h
+++ b/MXSegmentedPager/MXSegmentedPager.h
@@ -273,6 +273,19 @@ typedef void (^MXProgressBlock) (CGFloat progress);
 
 @end
 
+typedef NS_ENUM(NSInteger, MXParallaxHeaderStickyViewPosition) {
+    MXParallaxHeaderStickyViewPositionBottom = 0,
+    MXParallaxHeaderStickyViewPositionTop,
+};
+
+@interface MXParallaxHeader (StyckyHeader)
+@property (nonatomic, assign, readwrite) MXParallaxHeaderStickyViewPosition stickyViewPosition;
+@property (nonatomic, strong, nullable, readwrite) NSLayoutConstraint *stickyViewHeightConstraint;
+@property (nonatomic, strong, nullable, readwrite) UIView *stickyView;
+@property (nonatomic, assign, readonly, getter=isInsideTableView) BOOL insideTableView;
+- (void)setStickyView:(nullable __kindof UIView *)stickyView withHeight:(CGFloat)height;
+@end
+
 #pragma mark VGParallaxHeader Backward compatibility
 
 #define VGPARALLAXHEADER_DEPRECATION DEPRECATED_MSG_ATTRIBUTE("VGParallaxHeader has been deleted from MXSegmentedPager, use MXParallaxHeader instead.")
@@ -287,15 +300,7 @@ typedef NS_ENUM(NSInteger, VGParallaxHeaderMode) {
 typedef NS_ENUM(NSInteger, VGParallaxHeaderStickyViewPosition) {
     VGParallaxHeaderStickyViewPositionBottom = 0,
     VGParallaxHeaderStickyViewPositionTop,
-} VGPARALLAXHEADER_DEPRECATION;
-
-@interface MXParallaxHeader (VGParallaxHeader)
-@property (nonatomic, assign, readwrite) VGParallaxHeaderStickyViewPosition stickyViewPosition VGPARALLAXHEADER_DEPRECATION;
-@property (nonatomic, strong, nullable, readwrite) NSLayoutConstraint *stickyViewHeightConstraint VGPARALLAXHEADER_DEPRECATION;
-@property (nonatomic, strong, nullable, readwrite) UIView *stickyView VGPARALLAXHEADER_DEPRECATION;
-@property (nonatomic, assign, readonly, getter=isInsideTableView) BOOL insideTableView VGPARALLAXHEADER_DEPRECATION;
-- (void)setStickyView:(nullable __kindof UIView *)stickyView withHeight:(CGFloat)height VGPARALLAXHEADER_DEPRECATION;
-@end
+} DEPRECATED_MSG_ATTRIBUTE("VGParallaxHeader has been deleted from MXSegmentedPager, use MXParallaxHeaderStickyViewPosition instead.");
 
 @interface MXSegmentedPager (VGParallaxHeader)
 @property (nonatomic) CGFloat minimumHeaderHeight VGPARALLAXHEADER_DEPRECATION;

--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -310,39 +310,13 @@
 
 @end
 
-#pragma mark VGParallaxHeader Backward compatibility
+@implementation MXParallaxHeader (StyckyHeader)
 
-@implementation MXSegmentedPager (VGParallaxHeader)
-
-- (void)setParallaxHeaderView:(UIView *)view mode:(VGParallaxHeaderMode)mode height:(CGFloat)height {
-    self.parallaxHeader.view    = view;
-    self.parallaxHeader.mode    = (MXParallaxHeaderMode)mode;
-    self.parallaxHeader.height  = height;
-}
-
-- (void)updateParallaxHeaderViewHeight:(CGFloat)height {
-    self.parallaxHeader.height = height;
-}
-
-#pragma mark Properties
-
-- (CGFloat)minimumHeaderHeight {
-    return self.parallaxHeader.minimumHeight;
-}
-
-- (void)setMinimumHeaderHeight:(CGFloat)minimumHeaderHeight {
-    self.parallaxHeader.minimumHeight = minimumHeaderHeight;
-}
-
-@end
-
-@implementation MXParallaxHeader (VGParallaxHeader)
-
-- (VGParallaxHeaderStickyViewPosition)stickyViewPosition {
+- (MXParallaxHeaderStickyViewPosition)stickyViewPosition {
     return [objc_getAssociatedObject(self, @selector(stickyViewPosition)) integerValue];
 }
 
-- (void)setStickyViewPosition:(VGParallaxHeaderStickyViewPosition)stickyViewPosition {
+- (void)setStickyViewPosition:(MXParallaxHeaderStickyViewPosition)stickyViewPosition {
     objc_setAssociatedObject(self, @selector(stickyViewPosition), [NSNumber numberWithInteger:stickyViewPosition], OBJC_ASSOCIATION_COPY_NONATOMIC);
     [self updateStickyViewConstraints];
 }
@@ -392,8 +366,6 @@
     return NO;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)updateStickyViewConstraints {
     if (self.stickyView) {
         [self.stickyView removeFromSuperview];
@@ -405,7 +377,7 @@
                                                                                  metrics:nil
                                                                                    views:@{@"v" : self.stickyView}]];
         
-        NSLayoutAttribute attribute = (self.stickyViewPosition == VGParallaxHeaderStickyViewPositionTop)? NSLayoutAttributeTop : NSLayoutAttributeBottom;
+        NSLayoutAttribute attribute = (self.stickyViewPosition == MXParallaxHeaderStickyViewPositionTop)? NSLayoutAttributeTop : NSLayoutAttributeBottom;
         [self.contentView addConstraint:[NSLayoutConstraint constraintWithItem:self.stickyView
                                                                      attribute:attribute
                                                                      relatedBy:NSLayoutRelationEqual
@@ -417,6 +389,31 @@
         [self.contentView addConstraint:self.stickyViewHeightConstraint];
     }
 }
-#pragma GCC diagnostic pop
+
+@end
+
+#pragma mark VGParallaxHeader Backward compatibility
+
+@implementation MXSegmentedPager (VGParallaxHeader)
+
+- (void)setParallaxHeaderView:(UIView *)view mode:(VGParallaxHeaderMode)mode height:(CGFloat)height {
+    self.parallaxHeader.view    = view;
+    self.parallaxHeader.mode    = (MXParallaxHeaderMode)mode;
+    self.parallaxHeader.height  = height;
+}
+
+- (void)updateParallaxHeaderViewHeight:(CGFloat)height {
+    self.parallaxHeader.height = height;
+}
+
+#pragma mark Properties
+
+- (CGFloat)minimumHeaderHeight {
+    return self.parallaxHeader.minimumHeight;
+}
+
+- (void)setMinimumHeaderHeight:(CGFloat)minimumHeaderHeight {
+    self.parallaxHeader.minimumHeight = minimumHeaderHeight;
+}
 
 @end

--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -310,7 +310,7 @@
 
 @end
 
-@implementation MXParallaxHeader (StyckyHeader)
+@implementation MXParallaxHeader (StickyHeader)
 
 - (MXParallaxHeaderStickyViewPosition)stickyViewPosition {
     return [objc_getAssociatedObject(self, @selector(stickyViewPosition)) integerValue];


### PR DESCRIPTION
1) Add new MXParallaxHeaderStickyViewPosition enum and change VGParallaxHeaderStickyViewPosition deprecation message. 
2) Remove sticky header deprecation by using MXParallaxHeaderStickyViewPosition enum values as method parameter types.
