### PR TITLE
Update MXParallaxHeader Dependency

### DIFF
--- a/MXSegmentedPager.podspec
+++ b/MXSegmentedPager.podspec
@@ -29,6 +29,6 @@ Pod::Spec.new do |s|
   s.public_header_files = ["MXSegmentedPager/*.h"]
   s.dependency 'HMSegmentedControl', '~> 1.5.2'
   s.dependency 'MXPagerView', '~> 0.1.2'
-  s.dependency 'MXParallaxHeader', '~> 0.4.3'
+  s.dependency 'MXParallaxHeader', '~> 0.5.0'
   
 end


### PR DESCRIPTION
I wanted to use a newer Version of MXParallelHeader that includes the fix for https://github.com/maxep/MXParallaxHeader/issues/24 but for that, the dependency on MXParallaxHeader needs to be increase to 0.5.0 
