### PR TITLE
Avoid breaking constrains on setup

### DIFF
--- a/MXSegmentedPager/MXSegmentedPager.m
+++ b/MXSegmentedPager/MXSegmentedPager.m
@@ -178,7 +178,7 @@
 
 - (MXPagerView *)pager {
     if (!_pager) {
-        _pager = [[MXPagerView alloc] init];
+        _pager = [[MXPagerView alloc] initWithFrame:self.frame];
         _pager.delegate = self;
         _pager.dataSource = self;
         [self.contentView addSubview:_pager];


### PR DESCRIPTION
How to replicate:
- The bug happens when you setup MXSegmentedPager, it initialises `MXPagerView`  using `_pager = [[MXPagerView alloc] init];`, it means that `_pager` is being initialised with CGRectZero which breaks the layout constraints for the first view or page loaded.

Solution:
- My proposal is to initialise `_page` with same frame than its container `MXSegmentedPager`, which at least is an approximated frame for `_page` and not `CGRectZero`, which is an incoherent value. 

Also it fixes the bugs reported:
https://github.com/maxep/MXSegmentedPager/issues/83
https://github.com/maxep/MXSegmentedPager/issues/117
